### PR TITLE
Fix #13

### DIFF
--- a/book/source/text/06quantifiers.ptx
+++ b/book/source/text/06quantifiers.ptx
@@ -565,7 +565,7 @@ The domain of the quantifier remains unchanged when the statement is negated.
  <ul>
 <li> There is a real number <m>y</m> such that <m>1/y = y+1</m>.
 </li>
-<li> For every natural number <m>z</m> there is a natural number <m>w</m> such that <m>z^2 \lt  w</m>.
+<li> For every integer <m>z</m> there is a natural number <m>w</m> such that <m>z^2 \lt  w</m>.
 </li>
 </ul>
 </p>


### PR DESCRIPTION
A minor typo at the start of section 5.3 - example 5.3.1 had a "natural number" which should have been "integer".

Thanks to @divy-07 for reporting the error.

Fixes #13 